### PR TITLE
CMake compatible with git_submodule branch Moni-align

### DIFF
--- a/include/pfp/CMakeLists.txt
+++ b/include/pfp/CMakeLists.txt
@@ -2,5 +2,7 @@ set(PFP_SOURCES dictionary.hpp
                 parse.hpp
                 pfp.hpp)
 
-add_library(pfp OBJECT ${PFP_SOURCES})
-target_link_libraries(pfp common sdsl divsufsort divsufsort64)
+if (NOT TARGET pfp)
+    add_library(pfp OBJECT ${PFP_SOURCES})
+    target_link_libraries(pfp common sdsl divsufsort divsufsort64)
+endif()

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,27 +1,27 @@
 add_executable(pfp_thresholds pfp_thresholds.cpp)
-target_link_libraries(pfp_thresholds common pfp gsacak sdsl malloc_count zlib)
+target_link_libraries(pfp_thresholds common pfp gsacak sdsl malloc_count z)
 
 add_executable(pfp_thresholds64 pfp_thresholds.cpp)
-target_link_libraries(pfp_thresholds64 common pfp gsacak64 sdsl malloc_count zlib)
+target_link_libraries(pfp_thresholds64 common pfp gsacak64 sdsl malloc_count z)
 target_compile_options(pfp_thresholds64 PUBLIC -DM64)
 
 add_executable(pfp_lcp pfp_lcp.cpp)
-target_link_libraries(pfp_lcp common pfp gsacak sdsl malloc_count zlib)
+target_link_libraries(pfp_lcp common pfp gsacak sdsl malloc_count z)
 
 add_executable(pfp_lcp64 pfp_lcp.cpp)
-target_link_libraries(pfp_lcp64 common pfp gsacak64 sdsl malloc_count zlib)
+target_link_libraries(pfp_lcp64 common pfp gsacak64 sdsl malloc_count z)
 target_compile_options(pfp_lcp64 PUBLIC -DM64)
 
 add_executable(sdsl_thresholds sdsl_thresholds.cpp)
-target_link_libraries(sdsl_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64 zlib)
+target_link_libraries(sdsl_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64 z)
 
 if(${COMPILE_BWT2LCP})
     add_executable(bwt_lcp_thresholds bwt_lcp_thresholds.cpp)
-    target_link_libraries(bwt_lcp_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64 zlib)
+    target_link_libraries(bwt_lcp_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64)
     target_include_directories(bwt_lcp_thresholds PUBLIC "${rlbwt2lcp_SOURCE_DIR}/internal")
 
     add_executable(bwt_lcp bwt_lcp.cpp)
-    target_link_libraries(bwt_lcp common gsacak sdsl malloc_count divsufsort divsufsort64 zlib)
+    target_link_libraries(bwt_lcp common gsacak sdsl malloc_count divsufsort divsufsort64)
     target_include_directories(bwt_lcp PUBLIC "${bwt2lcp_SOURCE_DIR}/internal")
 endif()
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,27 +1,27 @@
 add_executable(pfp_thresholds pfp_thresholds.cpp)
-target_link_libraries(pfp_thresholds common pfp gsacak sdsl malloc_count)
+target_link_libraries(pfp_thresholds common pfp gsacak sdsl malloc_count zlib)
 
 add_executable(pfp_thresholds64 pfp_thresholds.cpp)
-target_link_libraries(pfp_thresholds64 common pfp gsacak64 sdsl malloc_count)
+target_link_libraries(pfp_thresholds64 common pfp gsacak64 sdsl malloc_count zlib)
 target_compile_options(pfp_thresholds64 PUBLIC -DM64)
 
 add_executable(pfp_lcp pfp_lcp.cpp)
-target_link_libraries(pfp_lcp common pfp gsacak sdsl malloc_count)
+target_link_libraries(pfp_lcp common pfp gsacak sdsl malloc_count zlib)
 
 add_executable(pfp_lcp64 pfp_lcp.cpp)
-target_link_libraries(pfp_lcp64 common pfp gsacak64 sdsl malloc_count)
+target_link_libraries(pfp_lcp64 common pfp gsacak64 sdsl malloc_count zlib)
 target_compile_options(pfp_lcp64 PUBLIC -DM64)
 
 add_executable(sdsl_thresholds sdsl_thresholds.cpp)
-target_link_libraries(sdsl_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64)
+target_link_libraries(sdsl_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64 zlib)
 
 if(${COMPILE_BWT2LCP})
     add_executable(bwt_lcp_thresholds bwt_lcp_thresholds.cpp)
-    target_link_libraries(bwt_lcp_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64)
+    target_link_libraries(bwt_lcp_thresholds common gsacak sdsl malloc_count divsufsort divsufsort64 zlib)
     target_include_directories(bwt_lcp_thresholds PUBLIC "${rlbwt2lcp_SOURCE_DIR}/internal")
 
     add_executable(bwt_lcp bwt_lcp.cpp)
-    target_link_libraries(bwt_lcp common gsacak sdsl malloc_count divsufsort divsufsort64)
+    target_link_libraries(bwt_lcp common gsacak sdsl malloc_count divsufsort divsufsort64 zlib)
     target_include_directories(bwt_lcp PUBLIC "${bwt2lcp_SOURCE_DIR}/internal")
 endif()
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -104,15 +104,21 @@ else()
     message(STATUS "sdsl sources found at ${SDSL_SRC}.")
 endif()
 
-add_library(sdsl STATIC IMPORTED GLOBAL)
-set_property(TARGET sdsl PROPERTY IMPORTED_LOCATION ${SDSL_LIB})
-target_include_directories(sdsl INTERFACE ${SDSL_SRC})
+if (NOT TARGET sdsl)
+    add_library(sdsl STATIC IMPORTED GLOBAL)
+    set_property(TARGET sdsl PROPERTY IMPORTED_LOCATION ${SDSL_LIB})
+    target_include_directories(sdsl INTERFACE ${SDSL_SRC})
+endif()
 
-add_library(divsufsort STATIC IMPORTED GLOBAL)
-set_property(TARGET divsufsort PROPERTY IMPORTED_LOCATION ${DIVSUFSORT_LIB})
-    
-add_library(divsufsort64 STATIC IMPORTED GLOBAL)
-set_property(TARGET divsufsort64 PROPERTY IMPORTED_LOCATION ${DIVSUFSORT64_LIB})
+if (NOT TARGET divsufsort)  
+    add_library(divsufsort STATIC IMPORTED GLOBAL)
+    set_property(TARGET divsufsort PROPERTY IMPORTED_LOCATION ${DIVSUFSORT_LIB})
+endif()
+
+if (NOT TARGET divsufsort64)
+    add_library(divsufsort64 STATIC IMPORTED GLOBAL)
+    set_property(TARGET divsufsort64 PROPERTY IMPORTED_LOCATION ${DIVSUFSORT64_LIB})
+endif()
 
 # HTSLIB
 find_library(HTS_LIB hts)
@@ -193,9 +199,11 @@ else()
     message(STATUS "htslib sources found at ${HTS_SRC}.")
 endif()
 
-add_library(htslib STATIC IMPORTED GLOBAL)
-set_property(TARGET htslib PROPERTY IMPORTED_LOCATION ${HTS_LIB})
-target_include_directories(htslib INTERFACE ${HTS_SRC})
+if (NOT TARGET htslib)
+    add_library(htslib STATIC IMPORTED GLOBAL)
+    set_property(TARGET htslib PROPERTY IMPORTED_LOCATION ${HTS_LIB})
+    target_include_directories(htslib INTERFACE ${HTS_SRC})
+endif()
 
 # PFP++
 find_program(PFP pfp++)


### PR DESCRIPTION
Add target guards on targets that have conflicts with other PFP projects. Also added zlib library to some of the targets since cmae was complaining about it being missing when building the git submodule branch of moni-align. 