### PR TITLE
Removed unnecessary isaD information to reduce memory usage of pfp build

### DIFF
--- a/include/pfp/dictionary.hpp
+++ b/include/pfp/dictionary.hpp
@@ -148,7 +148,7 @@ public:
     verbose("Computing ISA of dictionary");
     _elapsed_time(
       {
-        phrase_to_rank.resize(n_phrases());
+        phrase_to_rank.resize(n_phrases() + 1);
         for(size_t i = 0; i < saD.size(); ++i){
           if (b_d[saD[i]])
             phrase_to_rank[rank_b_d(saD[i])] = i;

--- a/include/pfp/pfp.hpp
+++ b/include/pfp/pfp.hpp
@@ -130,7 +130,7 @@ public:
     verbose("Dictionary");
     verbose("Size of dict.d: ", dict.d.size() * sizeof(dict.d[0]));
     verbose("Size of dict.saD: ", dict.saD.size() * sizeof(dict.saD[0]));
-    verbose("Size of dict.isaD: ", dict.isaD.size() * sizeof(dict.isaD[0]));
+    // verbose("Size of dict.isaD: ", dict.isaD.size() * sizeof(dict.isaD[0]));
     verbose("Size of dict.lcpD: ", dict.lcpD.size() * sizeof(dict.lcpD[0]));
     verbose("Size of dict.rmq_lcp_D: ", sdsl::size_in_bytes(dict.rmq_lcp_D));
 


### PR DESCRIPTION
Hi Max, I found a spot in pfp-thresholds where some extra data is being stored in memory which can be removed. (I found it originally in Mumemto, but it's the same code so I thought I'd send a PR here too for any tools that use pfp-thresholds).

The inverse suffix array of the dict is computed to [compute the LCP between phrases](https://github.com/maxrossi91/pfp-thresholds/blob/69cfd4baa1596d76a7b9b79dc3707f89af76be6c/include/pfp/dictionary.hpp#L95) in the dict. As far as I can tell, the `isaD` is not used anywhere else (`grep -r 'isaD' *` yields no other references). In this case, all we really need to store is the position in the saD of the phrase starts, since that's all that's used in `compute_pos_T`.

I replaced isaD with this vector and changed the usage in `longest_common_phrase_prefix` accordingly. In my few tests, I get the same results, but with up to 20% lower peak memory usage. We essentially save (|dict| - (# phrases)) * 8 bytes, which is quite substantial!